### PR TITLE
added switch to optionally disable IPv4

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -15,6 +15,9 @@ define('HOST', 'server');
 //Activate this only if you have IPv6 connectivity, or you *WILL* get errors.
 define('USE_IPV6', false);
 
+// Set this to false if you have set USE_IPV6 to true and only want IPv6 updates.
+define('USE_IPV4', true);
+
 //If set to true, this will change TTL to 300 seconds on every run if necessary.
 define('CHANGE_TTL', true);
 


### PR DESCRIPTION
This adds a switch `USE_IPV4` which can be used to disable updating the "A" record. A default setting to `true` is done in `config-dist.php`.  Set `USE_IPV4` to `false` and `USE_IPV6` to `true` to only update the "AAAA" record, e.g. when using this script on a DS-Lite connection.
