### PR TITLE
Fix typo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -339,7 +339,7 @@ function getCurrentPublicIPv6()
         }
 
         if (!isIPV6Valid($publicIP) || $publicIP === false) {
-            outputWarning("https://ip6.seeip.org didn't return a valid IPv4 address (Try $retryCount / $retryLimit). Trying fallback API https://v6.ident.me/");
+            outputWarning("https://ip6.seeip.org didn't return a valid IPv6 address (Try $retryCount / $retryLimit). Trying fallback API https://v6.ident.me/");
             $url = 'https://v6.ident.me/';
             $ch = initializeCurlHandlerGetIP($url);
             $publicIP = trim(curl_exec($ch));


### PR DESCRIPTION
This PR fixes a typo.

I noticed that this warning message contains a typo, when it failed to fetch the IPv6 address from ip6.seeip.org. Currently, only about 10% of requests to ip6.seeip.org succeed, but this may just be an temporary issue with the service.