### PR TITLE
Add support to run in docker container for systems without php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.2-cli-alpine
+COPY . /
+WORKDIR /
+
+ENV SCHEDULE="*/5 * * * *" \
+    CRON_CMD="php /update.php"
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/usr/sbin/crond", "-f"]
+
+SHELL ["/bin/ash"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Configuration is very simple:
 
 You should probably run this script every few minutes, so that your IP is updated as quickly as possible. Add it to your cronjobs and run it regularly, for example every five minutes.
 
+### How to use - alternative with Docker
+`docker compose up`
+
+The docker container includes the cronjob and runs by default every 5 minutes.
+
 ### CLI options
 Just add these Options after the command like `./update.php --quiet`
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  netcup-dyndns:
+    restart: unless-stopped
+    network_mode: host
+    environment:
+    - SCHEDULE="*/5 * * * *"
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/ash -e
+
+echo "startup $0"
+
+if [ ! -z "${SCHEDULE}" ] &&  [ ! -z "${CRON_CMD}" ]; then
+  echo "configure cron: ${SCHEDULE} ${CRON_CMD}"
+  echo "@reboot ${CRON_CMD}" > /etc/crontabs/root
+  echo "${SCHEDULE} ${CRON_CMD}" >> /etc/crontabs/root
+fi
+
+echo "run: $@"
+exec "$@"
+


### PR DESCRIPTION
Thanks for the script! Very helpful.

I am running the script on a host without php so I quickly containerized the application and created a docker-compose.yaml so that people can quickly start-up the application. The docker image is not pushed to any registry, thus it needs to be build on first clone (is done by docker compose automatically on first run).

Maybe this is helpful for some people. If you don't want to support it - no worries. Just close the PR without merge then.